### PR TITLE
refactor: add typename resolver and aggregate nodes field name config

### DIFF
--- a/lib/grasql/config.ex
+++ b/lib/grasql/config.ex
@@ -97,6 +97,7 @@ defmodule GraSQL.Config do
   ### Naming conventions
   * `aggregate_field_suffix` - Suffix for aggregate field names in GraphQL
   * `primary_key_argument_name` - Parameter name for single entity queries
+  * `aggregate_nodes_field_name` - Field name for nodes in aggregate queries (default: "nodes")
 
   ### Operator mappings
   * `operators` - Map of GraphQL operator suffixes for each operator type
@@ -116,6 +117,7 @@ defmodule GraSQL.Config do
           # Naming conventions
           aggregate_field_suffix: String.t(),
           primary_key_argument_name: String.t(),
+          aggregate_nodes_field_name: String.t(),
 
           # Operator mappings
           operators: %{operator => String.t()},
@@ -139,6 +141,7 @@ defmodule GraSQL.Config do
     # Naming conventions
     aggregate_field_suffix: "_agg",
     primary_key_argument_name: "id",
+    aggregate_nodes_field_name: "nodes",
 
     # Operator mappings - using standard GraphQL operator syntax
     operators: %{
@@ -310,6 +313,7 @@ defmodule GraSQL.Config do
     |> Map.take([
       :aggregate_field_suffix,
       :primary_key_argument_name,
+      :aggregate_nodes_field_name,
       :operators,
       :query_cache_max_size,
       :query_cache_ttl_seconds,
@@ -356,7 +360,8 @@ defmodule GraSQL.Config do
   @doc false
   defp validate_naming_conventions(config) do
     if is_binary(config.aggregate_field_suffix) and
-         is_binary(config.primary_key_argument_name) do
+         is_binary(config.primary_key_argument_name) and
+         is_binary(config.aggregate_nodes_field_name) do
       :ok
     else
       {:error, "Naming convention fields must be strings"}

--- a/lib/grasql/schema_resolver.ex
+++ b/lib/grasql/schema_resolver.ex
@@ -31,6 +31,11 @@ defmodule GraSQL.SchemaResolver do
         join_table: nil
       }
     end
+
+    @impl true
+    def resolve_typename(%GraSQL.Schema.Table{name: "users_table"}, _context) do
+      "User"  # Map "users_table" database table to "User" GraphQL type
+    end
   end
   """
 
@@ -96,6 +101,40 @@ defmodule GraSQL.SchemaResolver do
               parent_table :: GraSQL.Schema.Table.t(),
               context :: map()
             ) :: GraSQL.Schema.Relationship.t()
+
+  @doc """
+  Resolves the GraphQL __typename for a database table.
+
+  Determines what GraphQL type name should be used for a given database table.
+  This is used to include the __typename field in GraphQL responses.
+
+  ## Parameters
+
+  * `table` - The resolved database table
+  * `context` - Optional context map with user/tenant information
+
+  ## Returns
+
+  * A string representing the GraphQL type name, or nil to use the default naming
+
+  ## Example
+
+  ```elixir
+  def resolve_typename(%GraSQL.Schema.Table{name: "users"}, _context) do
+    "User"  # Map "users" table to "User" GraphQL type
+  end
+
+  # Fall back to default naming for other tables
+  def resolve_typename(_table, _context), do: nil
+  ```
+  """
+  @callback resolve_typename(
+              table :: GraSQL.Schema.Table.t(),
+              context :: map()
+            ) :: String.t() | nil
+
+  # Make resolve_typename an optional callback
+  @optional_callbacks [resolve_typename: 2]
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/grasql/simple_resolver.ex
+++ b/lib/grasql/simple_resolver.ex
@@ -11,6 +11,7 @@ defmodule GraSQL.SimpleResolver do
   * Tables are assumed to be in the "public" schema
   * Relationships use "id" as the source column
   * Target tables use "{parent_table_name}_id" as the foreign key
+  * GraphQL __typename is the table name with first letter capitalized
 
   For production use, implement your own resolver that provides
   actual database schema information.
@@ -92,5 +93,32 @@ defmodule GraSQL.SimpleResolver do
       type: :has_many,
       join_table: nil
     }
+  end
+
+  @impl true
+  @doc """
+  Resolves the GraphQL __typename for a database table.
+
+  Uses a simple convention: the table name with the first letter capitalized.
+
+  ## Parameters
+
+  * `table` - The resolved database table
+  * `_ctx` - Ignored context parameter
+
+  ## Returns
+
+  * A string representing the GraphQL type name
+
+  ## Examples
+
+      iex> table = %GraSQL.Schema.Table{schema: "public", name: "users"}
+      iex> GraSQL.SimpleResolver.resolve_typename(table, %{})
+      "Users"
+  """
+  @spec resolve_typename(GraSQL.Schema.Table.t(), map()) :: String.t()
+  def resolve_typename(%GraSQL.Schema.Table{name: name}, _ctx) do
+    # Simple implementation: capitalize the first letter of the table name
+    String.capitalize(name)
   end
 end

--- a/native/grasql/src/config.rs
+++ b/native/grasql/src/config.rs
@@ -17,6 +17,9 @@ pub struct Config {
     /// Argument name used for primary key in single record queries
     pub primary_key_argument_name: String,
 
+    /// Field name for nodes in aggregate queries
+    pub aggregate_nodes_field_name: String,
+
     /// Operator mappings from GraphQL to SQL
     pub operators: HashMap<String, String>,
 

--- a/test/grasql/config_test.exs
+++ b/test/grasql/config_test.exs
@@ -32,6 +32,9 @@ defmodule GraSQL.ConfigTest do
     test "rejects invalid naming conventions" do
       config = %Config{aggregate_field_suffix: :not_a_string}
       assert {:error, "Naming convention fields must be strings"} = Config.validate(config)
+
+      config = %Config{aggregate_nodes_field_name: :not_a_string}
+      assert {:error, "Naming convention fields must be strings"} = Config.validate(config)
     end
 
     test "rejects invalid max_query_depth" do
@@ -50,6 +53,12 @@ defmodule GraSQL.ConfigTest do
       assert {:error, "Naming convention fields must be strings"} =
                Config.validate(%Config{
                  primary_key_argument_name: nil
+               })
+
+      # Test with invalid aggregate_nodes_field_name
+      assert {:error, "Naming convention fields must be strings"} =
+               Config.validate(%Config{
+                 aggregate_nodes_field_name: nil
                })
     end
 
@@ -187,13 +196,15 @@ defmodule GraSQL.ConfigTest do
     test "preserves other configuration values" do
       config = %Config{
         query_cache_max_size: 2000,
-        query_cache_ttl_seconds: 7200
+        query_cache_ttl_seconds: 7200,
+        aggregate_nodes_field_name: "items"
       }
 
       native_config = Config.to_native_config(config)
 
       assert native_config.query_cache_max_size == 2000
       assert native_config.query_cache_ttl_seconds == 7200
+      assert native_config.aggregate_nodes_field_name == "items"
     end
 
     test "only passes necessary configuration to NIF, excluding module references" do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the field name used for nodes in aggregate queries.
  - Introduced the ability to annotate tables with a GraphQL `__typename` field, allowing custom or convention-based type names in responses.
- **Bug Fixes**
  - Improved validation to ensure configuration fields related to naming conventions are properly checked for correct types.
- **Documentation**
  - Updated documentation to describe new configuration options and the `__typename` resolution feature.
- **Tests**
  - Added tests to verify correct handling and validation of the new configuration and `__typename` functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->